### PR TITLE
fix UnboundLocalError: local variable 'sclangloc' referenced before assignment

### DIFF
--- a/src/boot/supercollider.py
+++ b/src/boot/supercollider.py
@@ -31,5 +31,7 @@ def find_path():
         print("Operating system unrecognised")
         #Potentially get the user to choose their OS from a list?
         #Then run the corresponding functions
+        
+        sclangloc = None
 
     return sclangloc

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -581,6 +581,9 @@ class SuperColliderInterpreter(BuiltinInterpreter, OSCInterpreter):
 
         sc_path = supercollider.find_path()
 
+        if sc_path is None: 
+            return
+        
         fn_path = supercollider.get_startup_file(*kwargs.get("lang_choices", [0, 0, 1])[:2]) # update with FoxDot and Tidal information
 
         os.chdir(os.path.dirname(sc_path))


### PR DESCRIPTION
for mac users, check that `sclangloc is None` in `find_path` before it causes other issues (breaking text buffer).

issue:
<img width="1035" alt="Screen Shot 2020-02-20 at 9 51 30 PM" src="https://user-images.githubusercontent.com/21090472/75000367-238da100-542c-11ea-9e47-33ed2d460df9.png">

after:
<img width="1433" alt="Screen Shot 2020-02-20 at 9 50 37 PM" src="https://user-images.githubusercontent.com/21090472/75000412-40c26f80-542c-11ea-8384-f98937b05e3f.png">

